### PR TITLE
Bump base lower bound

### DIFF
--- a/union-find.cabal
+++ b/union-find.cabal
@@ -28,7 +28,7 @@ Source-Repository head
 
 Library
   Build-Depends:
-    base >= 4 && < 5, containers >= 0.3, transformers >= 0.2
+    base >= 4.4 && < 5, containers >= 0.3, transformers >= 0.2
   GHC-Options:
     -Wall
   Exposed-Modules:


### PR DESCRIPTION
With GHC-7.0:

```
src/Data/UnionFind/ST.hs:153:37:
    No instance for (Applicative (ST s))
      arising from a use of `<*>'
    Possible fix: add an instance declaration for (Applicative (ST s))
    In the expression: (==) <$> repr p1 <*> repr p2
    In an equation for `equivalent':
        equivalent p1 p2 = (==) <$> repr p1 <*> repr p2
```

Published a new revision for `0.2` version on Hackage. https://hackage.haskell.org/package/union-find-0.2/revisions/
