### PR TITLE
QuickCheck tests for IntMap

### DIFF
--- a/src/Data/UnionFind/IntMap.hs
+++ b/src/Data/UnionFind/IntMap.hs
@@ -23,6 +23,7 @@ data Link a
      deriving Show
 
 newtype Point a = Point Int
+  deriving Eq
 
 newPointSupply :: PointSupply a
 newPointSupply = PointSupply 0 IM.empty

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE InstanceSigs         #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+module Common where
+
+import qualified Data.List                 as List
+import           Data.Map                  (Map)
+import qualified Data.Map                  as Map
+import           Data.Maybe
+import           Test.QuickCheck
+import           Test.QuickCheck.Arbitrary
+import           Test.QuickCheck.Gen
+
+-- | Model of a call to a Union Find implementation.
+--   An integer n in any of the value constructors refer
+--   to the n'th created point.
+data Call = Fresh Int | Union Int Int
+             deriving (Show, Eq)
+
+-- |Representation of a list of 'Call' values: this identifies a sequence of n
+--  consecutive operations, such as e.g. Fresh 0>Fresh 1>Union 0 1, that will
+--  result in a context with up to n sets once executed by the run function.
+newtype CallList = CL [Call] deriving (Show, Eq)
+
+-- Generators
+
+instance Arbitrary CallList where
+  arbitrary :: Gen CallList
+  arbitrary = simple
+  shrink :: CallList -> [CallList]
+  shrink (CL cs) = removePoint    cs ++
+                  removeNonFresh cs ++
+                  sortFreshFirst cs
+
+-- |Generates a 'CallList' in a meaningful way, i.e. avoiding calling
+--  operations before creating points with 'Fresh' and keeping track of the
+--  points already created.
+simple :: Gen CallList
+simple = do
+  cl <- s' 0
+  return $ CL cl
+  where
+    s' :: Int -- Points added so far
+          -> Gen [Call]
+    s' n_points = sized $ \remaining -> case () of
+     _| remaining <= 0 -> return []
+      | otherwise -> do
+        nonFreshCalls <- choose (0,n_points `div` 2) -- TODO should probably grow smarter
+        listOfNonFresh <- vectorOf nonFreshCalls $ 
+                              do n1 <- choose (0, n_points)
+                                 n2 <- choose (0, n_points)
+                                 return (Union n1 n2)
+        rec <- resize (max 0 (remaining-nonFreshCalls-1)) $ s' (n_points+1)
+        return $ (Fresh n_points):(listOfNonFresh++rec)
+
+
+-- Shrinking
+
+-- | For each fresh call,
+--     return one [Call] missing it and all other calls referencing that point.
+--     Decrements the indexes of points bigger than the one removed.
+removePoint :: [Call] -> [CallList]
+removePoint cs =
+  let n_fresh = numberOfFresh cs
+  in map
+      (\id -> CL $ restoreIdGap id $ filterPoint id cs)
+      [0..(n_fresh-1)]
+  where
+    filterPoint :: Int -> [Call] -> [Call]
+    filterPoint id = filter $ predC (/=id)
+    restoreIdGap :: Int -> [Call] -> [Call]
+    restoreIdGap id = map $ mapC (\p -> if p>id then p-1 else p)
+
+-- | For each non-fresh call,
+--     remove one [Call] missing it
+removeNonFresh :: [Call] -> [CallList]
+removeNonFresh cs =
+  let n = length cs
+  in map CL $ filter (/=[]) $ map
+      (\i -> removeIfNotFresh i cs)
+      [0..(n-1)]
+  where
+    removeIfNotFresh :: Int -> [Call] -> [Call]
+    removeIfNotFresh i cs | isFresh (cs!!i) = []
+                          | otherwise = (take i cs) ++ (drop (i+1) cs)
+
+-- | If not all fresh calls are first,
+--     return one [Call] where they are
+sortFreshFirst :: [Call] -> [CallList]
+sortFreshFirst cs =
+  if allFreshFirst cs then [] else [CL (sort cs)]
+  where
+    sort :: [Call] -> [Call]
+    sort cs = filter isFresh cs ++ (filter (not . isFresh) cs)
+
+-- Helpers
+
+-- | Map the internal id's of the calls
+mapC :: (Int -> Int) -> Call -> Call
+mapC f c = case c of
+  Fresh i     -> Fresh (f i)
+  Union i1 i2 -> Union (f i1) (f i2)
+
+-- |'mapC' extended to a list of 'Call's.
+mapCs :: (Int -> Int) -> [Call] -> [Call]
+mapCs f = map (mapC f)
+
+-- |Applies a given function to the index enclosed in a 'Call'. Internal use.
+predC :: (Int -> Bool) -> Call -> Bool
+predC p c = case c of
+  Fresh i     -> p i
+  Union i1 i2 -> (p i1) && (p i2)
+
+-- |Returns 'True' if the input call is a 'Fresh'.
+isFresh :: Call -> Bool
+isFresh c = case c of
+  Fresh _ -> True
+  _       -> False
+
+-- |Returns 'True' if all the 'Fresh' calls are at the start of the list.
+allFreshFirst :: [Call] -> Bool
+allFreshFirst = null . dropWhile (not.isFresh) . dropWhile isFresh
+
+-- |Returns the number of 'Fresh' calls inside a list.
+numberOfFresh :: [Call] -> Int
+numberOfFresh = length . filter isFresh
+
+
+-- Tests
+
+-- |Checks if all indices in the given 'CallList' are meaningful
+--  (i.e. non negative, within the number of existing points).
+prop_refsInRange :: CallList -> Property
+prop_refsInRange (CL cs) = aboveZero cs .&&. belowExisting cs
+
+-- |Checks if 'prop_refsInRange' is holds for shrinked CallLists.
+prop_refsInRange_shrink :: CallList -> Property
+prop_refsInRange_shrink cl =
+  let shrinks = shrink cl
+  in conjoin $ map prop_refsInRange shrinks
+
+aboveZero :: [Call] -> Property
+aboveZero cs =
+  counterexample (show cs) (property $ and $ map (predC (>=0)) cs)
+
+belowExisting :: [Call] -> Property
+belowExisting cs =
+  counterexample (show cs) (property $ internal cs 0)
+  where
+    internal cs n = case cs of
+      []            -> True
+      (Fresh _:cs') -> internal cs' (n+1)
+      (c:cs')       -> predC (<n) c && internal cs' n
+
+-- |Checks that the 'Fresh' calls are not invoked out of order, e.g.
+--  [Fresh 1,Fresh 3,Union 1 3,Fresh 2,Union 1 3] will result in an
+--  error since Fresh 3 can't be called before Fresh 2.
+prop_pointsContinious :: CallList -> Property
+prop_pointsContinious (CL cs) =
+  counterexample (show cs) (property $ internal (filter isFresh cs) 0)
+  where
+  internal cs n = case cs of
+    []              -> True
+    (Fresh i : cs') -> i==n && internal cs' (n+1)
+
+-- |Checks if 'prop_pointsContinious' is holds for shrinked CallLists.
+prop_pointsContinious_shrink :: CallList -> Property
+prop_pointsContinious_shrink cl =
+  let shrinks = shrink cl
+  in conjoin $ map prop_pointsContinious shrinks
+

--- a/test/IntMapProps.hs
+++ b/test/IntMapProps.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE InstanceSigs     #-}
+
+module IntMapProps where
+
+import           Common
+import qualified Data.List             as List
+import           Data.Map              ((!))
+import qualified Data.Map              as Map
+import           Data.Maybe
+import           Data.UnionFind.IntMap
+import           Test.QuickCheck
+
+-- |'PointEnvironment' is a data type containing 'PointSupply' and a reference to all
+--  'Point's created, plus a reference to the original 'CallList' for internal
+--  use.
+--  The enclosed 'PointSuppy' contains Points with descriptors 0..(nPoints-1).
+--  This data type is needed as the user of Data.UnionFind.IntMap.PointSupply need to
+--  keep track of the points created.
+data PointEnvironment = PE {
+  pointSupply    :: PointSupply Int,
+  pointMap       :: Map.Map Int (Point Int),
+  nPoints        :: Int,
+  sourceCallList :: CallList
+}
+
+-- |Custom 'Show' instance because no 'Show' is derived by 'Point's in IntMap.
+--  Data shown is 'PointSupply', number of points and number of sets.
+instance Show PointEnvironment where
+  show pe = "("++show (pointSupply pe)++" with "
+    ++show (nPoints pe)++" points in "
+    ++show (n_sets pe)++" sets)"
+
+-- |Invokes the generator functions in the Common module to create a random
+--  'CallList' and generates a 'PointEnvironment' from it.
+instance Arbitrary PointEnvironment where
+  arbitrary :: Gen PointEnvironment
+  arbitrary = do
+    cl <- arbitrary
+    return $ runCalls cl
+  shrink :: PointEnvironment -> [PointEnvironment]
+  shrink (PE _ _ _ cl) = map runCalls (shrink cl)
+
+-- |Generates a 'PointEnvironment' from a given 'CallList'. Internal use.
+runCalls :: CallList -> PointEnvironment
+runCalls cl@(CL cs) = foldl doCall (PE newPointSupply Map.empty 0 cl) cs
+
+-- |Executes a 'Call' to a given 'PointEnvironment' and returns the result.
+doCall :: PointEnvironment -> Call -> PointEnvironment
+doCall pe@(PE pSup pM n cl) call = case call of
+  Fresh _       -> let (pSup',p) = fresh pSup n
+                   in  PE pSup' (Map.insert n p pM) (n+1) cl
+  Union p1 p2   -> let p1' = fromJust $ Map.lookup p1 pM
+                       p2' = fromJust $ Map.lookup p2 pM
+                   in  pe{pointSupply = union pSup p1' p2'}
+
+-- |Helper function for 'PointEnvironment': extracts nr. of sets.
+n_sets :: PointEnvironment -> Int
+n_sets pe = length $ List.nub $ map (descriptor pSup) (Map.elems pm)
+  where
+    pSup = pointSupply pe
+    pm  = pointMap pe
+
+-- |Helper function for 'PointEnvironment': extracts all representatives.
+reps :: PointEnvironment -> [Point Int]
+reps pe = snd $ unzip $ List.nubBy same descriptorRepr
+  where
+    descriptorRepr = [(descriptor pSup p,repr pSup p)|p<-Map.elems pm]
+    same           = \(d,_) (d',_) -> d==d'
+    pSup           = pointSupply pe
+    pm             = pointMap pe
+
+-- |Helper function for 'PointEnvironment': extracts all entries (Int,Point Int)
+--  in the same set as the given point.
+pairsOfSet :: PointEnvironment -> Point Int -> [(Int,Point Int)]
+pairsOfSet pe r = [(k,p)|(k,p)<-Map.toList pm, p `sameSet` r]
+  where
+    pSup         = pointSupply pe
+    pm          = pointMap pe
+    sameSet a b = descriptor pSup a == descriptor pSup b
+
+-- |Helper function for 'PointEnvironment': extracts all points in the same
+--  set as the given point.
+elemsOfSet :: PointEnvironment -> Point Int -> [Point Int]
+elemsOfSet pe r = map snd $ pairsOfSet pe r
+
+-- |Helper function for 'PointEnvironment': extracts all points, grouped up
+--  by their respective sets.
+pointsBySet :: PointEnvironment -> [[Point Int]]
+pointsBySet pe = map (elemsOfSet pe) (reps pe)
+
+-- |Helper function for 'PointEnvironment': decides whether two sets are equivalent,
+--  i.e. if they have the same number of points, the same number of sets, each
+--  with the same number of elements, and whether the points in each set have
+--  the same key in the given PointEnvironment's inner map.
+sameSets :: PointEnvironment -> PointEnvironment -> Bool
+sameSets pe1 pe2 = sameNrPoints && sameNrSets && sameNrElems && samePoints
+  where
+    pm1          = pointMap pe1
+    pm2          = pointMap pe2
+    sets1        = pointsBySet pe1
+    sets2        = pointsBySet pe2
+    keysBySet pe = map (map fst) (map (pairsOfSet pe) (reps pe))
+    sameNrPoints = length pm1 == length pm2
+    sameNrSets   = length sets1 == length sets2
+    sameNrElems  = all (\(x,y) -> length x == length y) (zip sets1 sets2)
+    samePoints   = List.sort (keysBySet pe1) == List.sort (keysBySet pe2)
+
+-- |Verifies property: given any environment, ensures that any fresh point
+--  is always disjoint to all other points in the pointSupply.
+prop_newPointDisjoint :: PointEnvironment -> Bool
+prop_newPointDisjoint pe =
+  let pSup      = pointSupply pe
+      pm       = pointMap pe
+      next     = nPoints pe
+      (pSup',p) = fresh pSup next
+  in  not $ or $ map (equivalent pSup' p) (Map.elems pm)
+
+-- |Verifies property: given an environment with at least one point, ensures
+--  that relationships between existing points are not affected by 'fresh'.
+prop_sameReprAfterFresh :: PointEnvironment -> Bool
+prop_sameReprAfterFresh pe = and $ map sameReprAsBefore points
+  where
+    pe'                = pe `doCall` (Fresh (nPoints pe))
+    pSup               = pointSupply pe
+    pSup'              = pointSupply pe'
+    points             = Map.elems $ pointMap pe
+    sameReprAsBefore p = descriptor pSup p == descriptor pSup' p
+
+-- |Verifies property: given an environment with at least one point, ensures
+--  that all points in a set have the same representative as the representative
+--  of the set.
+prop_sameReprAsRepr :: PointEnvironment -> Property
+prop_sameReprAsRepr pe = n_sets pe > 0 ==> -- n = 0: trivially true
+  let r = head $ reps pe
+      pSup = pointSupply pe
+      sameAs p p' = descriptor pSup p == descriptor pSup p'
+  in  and $ map (\p -> p `sameAs` r) (pe `elemsOfSet` r)
+
+-- |Verifies property: given an environment with at least two points, ensures
+--  that if two points are in the same set, then their representative is the
+--  same and vice versa.
+prop_sameSetSameRepr :: PointEnvironment -> Property
+prop_sameSetSameRepr pe = nPoints pe > 1 ==>
+  let pSup = pointSupply pe
+      sameAs p p' = descriptor pSup p == descriptor pSup p'
+      p:points = elemsOfSet pe $ head $ reps pe
+  in  and $ map (sameAs p) points
+
+-- |Verifies property: given 'pSup' and two points 'p1', 'p2' contained in it,
+--  after the execution of 'union' 'pSup' 'p1' 'p2' the two points will have
+--  the same representative.
+prop_sameReprAfterUnion :: PointEnvironment -> Property
+prop_sameReprAfterUnion pe = n_sets pe > 1 ==>
+  let ((p1:_):(p2:_):_) = pointsBySet pe
+      pSup = pointSupply pe
+      pSup' = union pSup p1 p2
+      sameAs p p' = descriptor pSup p == descriptor pSup p'
+  in  (repr pSup' p1) `sameAs` (repr pSup' p2)
+
+-- |Verifies property: given 'pSup' and two points 'p1', 'p2' contained in it,
+--  after the execution of 'pSup2' = 'union' 'pSup' 'p1' 'p2', invoking
+--  'equivalent' 'pSup2' 'p1' 'p2' will return 'True'.
+prop_sameSetAfterUnion :: PointEnvironment -> Property
+prop_sameSetAfterUnion pe = n_sets pe > 1 ==>
+  let ((p1:_):(p2:_):_) = pointsBySet pe
+      pSup = pointSupply pe
+      pSup' = union pSup p1 p2
+  in  equivalent pSup' p1 p2
+
+-- | Transitivity in respect to set membership equivalence.
+-- x=y && y=z => x=z
+prop_transitivity :: PointEnvironment -> Property
+prop_transitivity (PE pSup pM n _cl) = n > 2 ==>
+  and [not (equivalent pSup (pM!x) (pM!y) &&
+            equivalent pSup (pM!y) (pM!z))
+       || equivalent pSup (pM!x) (pM!z)
+      | x<-[0..(n-1)], y<-[0..x], z<-[0..y]
+      ]
+
+-- | Commutativity in respect to set membership equivalence.
+prop_commutativity_eq :: PointEnvironment -> Bool
+prop_commutativity_eq (PE pSup pM n _cl) =
+  and [equivalent pSup (pM!x) (pM!y) ==
+       equivalent pSup (pM!y) (pM!x)
+      | x<-[0..(n-1)], y<-[0..x]
+      ]
+
+-- | Reflexivity in respect to set membership equivalence.
+prop_reflexivity_eq :: PointEnvironment -> Bool
+prop_reflexivity_eq (PE pSup pM n _cl) =
+  and $ [equivalent pSup (pM!x) (pM!x)
+        | x<-[0..(n-1)]
+        ]
+
+-- | Associativity in respect to set membership equivalence.
+prop_associativity :: PointEnvironment -> Property
+prop_associativity pe@(PE pSup pM _n _cl) =
+  let rs = reps pe
+      left  = union (union pSup (rs!!0) (rs!!1)) (rs!!1) (rs!!2)
+      right = union (union pSup (rs!!1) (rs!!2)) (rs!!0) (rs!!1)
+  in  (length rs >= 3) ==>
+        sameSets pe{pointSupply=left} pe{pointSupply=right}
+

--- a/test/TestSuite.hs
+++ b/test/TestSuite.hs
@@ -1,0 +1,30 @@
+module TestSuite (tests) where
+
+import           Distribution.TestSuite
+import           Distribution.TestSuite.QuickCheck
+import qualified Common
+import qualified IntMapProps
+
+tests :: IO [Test]
+tests = return
+  [ Group "Common (test model)" True [
+      testProperty "refsInRange"        Common.prop_refsInRange
+    , testProperty "refsInRange_shrink" Common.prop_refsInRange_shrink
+    , testProperty "pointsContinious"   Common.prop_pointsContinious
+    , testProperty "pointsContinious_shrink" Common.prop_pointsContinious_shrink
+    ],
+    Group "IntMap" True [
+      testProperty "newPointDisjoint"   IntMapProps.prop_newPointDisjoint
+    , testProperty "sameReprAfterFresh" IntMapProps.prop_sameReprAfterFresh
+    , testProperty "sameReprAsRepr"     IntMapProps.prop_sameReprAsRepr
+    , testProperty "sameSetSameRepr"    IntMapProps.prop_sameSetSameRepr
+    , testProperty "sameReprAfterUnion" IntMapProps.prop_sameReprAfterUnion
+    , testProperty "sameSetAfterUnion"  IntMapProps.prop_sameSetAfterUnion
+    , testProperty "transitivity"       IntMapProps.prop_transitivity
+    , testProperty "commutativity_eq"   IntMapProps.prop_commutativity_eq
+    , testProperty "reflexivity_eq"     IntMapProps.prop_reflexivity_eq
+    , testProperty "associativity"      IntMapProps.prop_associativity
+    ]
+  ]
+
+

--- a/union-find.cabal
+++ b/union-find.cabal
@@ -19,7 +19,7 @@ Description:
 Category:        Algorithms, Data
 Stability:       provisional
 Build-Type:      Simple
-Cabal-Version:   >= 1.6
+Cabal-Version:   >= 1.8
 Extra-Source-Files: README.md
 Bug-Reports:     http://github.com/nominolo/union-find/issues
 Source-Repository head
@@ -37,4 +37,20 @@ Library
     Data.UnionFind.ST
     Data.UnionFind.IntMap
   Hs-Source-Dirs: src
+
+Test-Suite QuickCheckTests
+  type: detailed-0.9
+  Hs-Source-Dirs: test
+  test-module: TestSuite
+  other-modules:
+      Common
+    , IntMapProps
+  Build-Depends:
+      union-find
+    , base
+    , Cabal >= 1.20.0
+    , QuickCheck  >= 2.4
+    , cabal-test-quickcheck >= 0.1.8.1
+    , random >= 1.0.1
+    , containers >= 0.3
 


### PR DESCRIPTION
Added QuickCheck tests for IntMap (didn't have time for more)

Important change in need of approval, we added `deriving Eq` to `Data.UnionFind.IntMap.Point`. The only other way to compare the descriptors of the points in the current implementation is to compare descriptors. As it is, only the representative point keep the descriptor, so it is not a very direct means of comparing (but it would possibly turn out correct anyway). A user of the library might also want to be able to compare Points, however, the users shouldn't confuse `==` with the function `equivalence`. 

Description solution:
- test/TestSuite.hs is called by `cabal test` and itself reference the quickCheck property tests.
- test/Common.hs define a model for testing. It is essentially a list of "Calls", a type representing abstract API calls.
- test/IntMapProps.hs uses Common as it tests IntMap.

We are two students (@dfurian) enrolled in a advanced functional programming course. We were told to contribute to an open source project and ended up here :) Unfortunately we did not have time to test the whole library, but hope it can be of any use.